### PR TITLE
Update URLs and some content (fixes #9)

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,16 +14,16 @@
         <meta name="viewport" content="width=device-width">
         <meta name="author" content="">
 
-        <meta property="og:title" content="minimal.iOS.8" />
-        <meta property="og:description" content="Flat, minimal Winterboard theme for iOS 8.X" />
-        <meta property="og:url" content="http://colbyfayock.github.io/minimal.iOS.8" />
-        <meta property="og:site_name" content="minimal.iOS.8" />
+        <meta property="og:title" content="minimal.iOS.9" />
+        <meta property="og:description" content="Flat, minimal Winterboard theme for iOS 9.X - 11.X" />
+        <meta property="og:url" content="http://colbyfayock.github.io/minimal.iOS.9" />
+        <meta property="og:site_name" content="minimal.iOS.9" />
         <meta property="og:image" content="http://cdn.fay.io/images/2014/minimal.ios.8-iphone-ios8-winterboard-theme.png" />
 
         <meta name="twitter:card" content="photo" />
         <meta name="twitter:site" content="@colbyfayock" />
-        <meta name="twitter:title" content="minimal.iOS.8 - Flat, minimal Winterboard theme for iOS 8.X" />
-        <meta name="twitter:url" content="http://colbyfayock.github.io/minimal.iOS.8/" />
+        <meta name="twitter:title" content="minimal.iOS.9 - Flat, minimal Winterboard theme for iOS 9.X - 11.X" />
+        <meta name="twitter:url" content="http://colbyfayock.github.io/minimal.iOS.9/" />
         <meta name="twitter:image" content="http://cdn.fay.io/images/2014/minimal.ios.8-iphone-ios8-winterboard-theme.png" />
         <meta name="twitter:image:width" content="800" />
         <meta name="twitter:image:height" content="600" />
@@ -56,11 +56,11 @@
 
             <div class="row">
                 <div class="twelvecol align-center">
-                    <a class="button button-cydia cydia-link" href="http://cydia.saurik.com/package/com.modmyi.minimalios8/">
+                    <a class="button button-cydia cydia-link" href="https://cydia.saurik.com/api/share#?source=http://cydia.fay.io/&package=io.fay.minimalios9.dev">
                         <i class="fa fa-dropbox"></i>
                         minimal.iOS.9 on Cydia
                     </a>
-                    <a class="button button-github" href="https://github.com/colbyfayock/minimal.iOS.8">
+                    <a class="button button-github" href="https://github.com/colbyfayock/minimal.iOS.9">
                         <i class="fa fa-github"></i>
                         minimal.iOS.9 on Github
                     </a>


### PR DESCRIPTION
This ensures the websites lists minimal.ios.9 rather than minimal.ios.8 and also links properly to Cydia for it

Clarification for line 59: This URL scheme lets people open the URL in Safari which presents them with an "Open in Cydia" button. Upon loading in Cydia there is a "Add repo" button and once that is done there is a "Continue to package" button to directly jump to the package.